### PR TITLE
Perfomance : changed batch submit and consumer get logic

### DIFF
--- a/benchmark/benchmark_throughput.py
+++ b/benchmark/benchmark_throughput.py
@@ -1,0 +1,126 @@
+"""
+Benchmarking 1_000_000 tasks using :
+    - 2 nodes
+    - 1 thread per process
+    - 4 queues
+    - 8 consumers
+The tasks were chunked using  into 1000 calls of 1000 tasks per batch
+The client submits to the QueuePool manager using
+The function is 'empty' : just passes and doesn't use CPU or IO
+
+Processing 1_000_000 empty tasks took 338s = 5min36s
+"""
+
+import itertools
+import os
+import time
+from typing import Callable
+
+import pandas as pd
+from daskqueue import ConsumerPool, QueuePool
+import daskqueue
+from daskqueue.utils import logger
+from distributed import Client, LocalCluster
+from datetime import datetime
+
+
+def save_results(params):
+    result_path = "/home/amine/Documents/programming/dask-queue/benchmark/results.csv"
+    if os.path.exists(result_path):
+        df = pd.read_csv(result_path)
+        df = df.append(params, ignore_index=True)
+        df.to_csv(result_path, index=False)
+    else:
+        df = pd.DataFrame([params])
+        df.to_csv(result_path, index=False)
+
+
+def batch_submit(queue_pool, func: Callable):
+    # queue_pool.submit(func, *args)
+    queue_pool.batch_submit([(func,) for _ in range(100)])
+
+
+def slowinc(x, delay=0.1):
+    time.sleep(delay)
+    return x + 1
+
+
+def run(params):
+    cluster = LocalCluster(
+        n_workers=4,
+        threads_per_worker=params["thread_per_consumer"],
+        dashboard_address=":3338",
+    )
+    client = Client(
+        cluster,
+        direct_to_workers=True,
+    )
+
+    queue_pool = QueuePool(client, params["n_queues"])
+
+    consumer_pool = ConsumerPool(
+        client,
+        queue_pool,
+        n_consumers=params["n_consumers"],
+        max_concurrency=params["max_concurrency"],
+    )
+
+    tic = time.perf_counter()
+    consumer_pool.start(timeout=1)
+
+    for _ in range(params["n_calls"]):
+        queue_pool.submit(slowinc, 1, params["task_duration"])
+
+    consumer_pool.join(timestep=0.001)
+    toc = time.perf_counter()
+
+    print(f"Processed all items in  {toc - tic:0.4f} seconds")
+
+    params["job_time"] = toc - tic
+    params["version"] = str(daskqueue.__version__)
+    params["timestamp"] = datetime.now()
+
+    save_results(params)
+    client.close()
+    cluster.close()
+
+
+if __name__ == "__main__":
+    ## Params
+    n_queues = [1, 2]
+    n_consumers = [10]
+    thread_per_consumer = [1]
+    max_concurrency = [1]
+    task_duration = [0.1]
+    task_release_GIL = [False]
+    n_calls = [10000, 20000]
+
+    list = [
+        n_queues,
+        n_consumers,
+        thread_per_consumer,
+        max_concurrency,
+        task_duration,
+        task_release_GIL,
+        n_calls,
+    ]
+
+    combinations = [p for p in itertools.product(*list)]
+    combination = pd.DataFrame(
+        combinations,
+        columns=(
+            "n_queues",
+            "n_consumers",
+            "thread_per_consumer",
+            "max_concurrency",
+            "task_duration",
+            "task_release_GIL",
+            "n_calls",
+        ),
+    )
+    df = combination[(combination.n_queues <= combination.n_consumers)]
+    df = df[((df.n_calls >= 1000) & (df.n_consumers > 2)) | ((df.n_calls < 1000))]
+
+    for _, params in df.iterrows():
+        logger.info(f"Run params :{params}")
+        run(params=params)

--- a/daskqueue/ConsumerPool.py
+++ b/daskqueue/ConsumerPool.py
@@ -82,19 +82,17 @@ class ConsumerPool:
         )
         start_join = time.time()
         while True:
-            done_consumers = sum([c.done().result() for c in self.consumers.values()])
-            if done_consumers < len(self.consumers):
-                logger.debug(
-                    f"[{done_consumers}/{len(self.consumers)} done]. Still processing..."
-                )
+            done_consumers = all([c.done().result() for c in self.consumers.values()])
+            if not done_consumers:
                 if progress and (time.time() - start_join > print_timestep):
+                    logger.debug("Still processing...")
                     logger.info(self.queue_pool.print().result())
                     logger.info(self)
                     start_join = time.time()
                 time.sleep(timestep)
             else:
                 logger.info(
-                    f"[{done_consumers}/{len(self.consumers)}]. All consumers are done !"
+                    f"All consumers are done ! {self.nb_consumed()} items processed. "
                 )
                 break
         self.cancel()

--- a/daskqueue/ConsumerPool.py
+++ b/daskqueue/ConsumerPool.py
@@ -78,7 +78,7 @@ class ConsumerPool:
         while True:
             done_consumers = sum([c.done().result() for c in self.consumers.values()])
             if done_consumers < len(self.consumers):
-                logger.info(
+                logger.debug(
                     f"[{done_consumers}/{len(self.consumers)} done]. Still processing..."
                 )
                 if progress:
@@ -103,4 +103,4 @@ class ConsumerPool:
     def cancel(self) -> None:
         """Cancels the consume loop task in each consumer."""
         logger.info(f"Cancelling {self.n_consumers} consumers.")
-        [c.cancel() for c in self.consumers.values()]
+        [c.cancel().result() for c in self.consumers.values()]

--- a/daskqueue/Queue.py
+++ b/daskqueue/Queue.py
@@ -42,7 +42,7 @@ class QueueActor:
 
     async def put_many(self, list_items):
         for item in list_items:
-            asyncio.create_task(self.queue.put(item))
+            await self.queue.put(item)
 
     async def put(self, item, timeout=None):
         try:

--- a/daskqueue/QueuePool.py
+++ b/daskqueue/QueuePool.py
@@ -42,7 +42,7 @@ class QueuePoolActor:
             for k in self._queue_size
         ]
 
-        return f"QueuePool : \n\t{self.n_queues} queue(s)" + "".join(qsize)
+        return f"QueuePool : {self.n_queues} queue(s)" + "".join(qsize)
 
     def get_queue(self, idx: int) -> QueueActor:
         return self._queues[idx]

--- a/daskqueue/QueuePool.py
+++ b/daskqueue/QueuePool.py
@@ -38,8 +38,8 @@ class QueuePoolActor:
 
     def print(self) -> str:
         qsize = [
-            f"\n\t{k}: {self._queue_size[k] if self._queue_size[k]>=0 else 0} pending items"
-            for k in self._queue_size
+            f"\n\t{idx}: {q.qsize().result()} pending items"
+            for idx, q in self._index_queue.items()
         ]
 
         return f"QueuePool : {self.n_queues} queue(s)" + "".join(qsize)
@@ -57,12 +57,16 @@ class QueuePoolActor:
         ]
 
     def get_queue_size(self) -> Dict[str, int]:
-        return self._queue_size
+        return [q.qsize().result() for q in self._index_queue.values()]
 
     def _get_random_queue(self) -> QueueActor:
         idx = np.random.randint(len(self._queues))
         return self._queues[idx]
 
+    async def get_queues(self) -> List[QueueActor]:
+        return self._queues
+
+    # TODO : Don't need this
     async def get_max_queue(self) -> QueueActor:
         key_queue = max(zip(self._queue_size.values(), self._queue_size.keys()))[1]
         self._queue_size[key_queue] -= 1

--- a/daskqueue/QueuePool.py
+++ b/daskqueue/QueuePool.py
@@ -68,6 +68,9 @@ class QueuePoolActor:
     async def get_queues(self) -> List[QueueActor]:
         return self._queues
 
+    async def get_queue(self, idx: int) -> QueueActor:
+        return self._queues[idx]
+
     def get_queue_size(self) -> Dict[str, int]:
         return {q: q.qsize().result() for q in self._queues}
 
@@ -75,7 +78,7 @@ class QueuePoolActor:
         idx = np.random.randint(len(self._queues))
         return self._queues[idx]
 
-    # TODO : Don't need this
+    # TODO : Don't need this ??
     async def get_max_queue(self) -> QueueActor:
         queues_size = self.get_queue_size()
         logger.info(f"queues_size : {queues_size}")
@@ -155,21 +158,6 @@ class QueuePoolActor:
             ## TODO : implement canceling tasks  in Queue and QueuePool
             raise PutTimeout(f"Couldn't put all element in queue : {q}")
 
-    async def get(self, timeout=None):
-        try:
-            q = await self.get_max_queue()
-            return await q.get(timeout)
-        except asyncio.TimeoutError:
-            # TODO : Reincrement the q , no item retrieved
-            return None
-
-    async def get_nowait(self):
-        try:
-            q = await self.get_max_queue()
-            return await q.get_nowait()
-        except asyncio.QueueEmpty:
-            return None
-
     def put_nowait_batch(self, items):
         pass
         # # If maxsize is 0, queue is unbounded, so no need to check size.
@@ -177,18 +165,6 @@ class QueuePoolActor:
         #     pass
         # for item in items:
         #     self.queue.put_nowait(item)
-
-    def get_nowait_batch(self, num_items):
-        pass
-        # if num_items > self.qsize():
-        #     # raise Empty(
-        #     #     f"Cannot get {num_items} items from queue of size " f"{self.qsize()}."
-        #     # )
-        #     pass
-        # return [self.queue.get_nowait() for _ in range(num_items)]
-
-        #     pass
-        # return [self.queue.get_nowait() for _ in range(num_items)]
 
 
 def decorator(cls):

--- a/daskqueue/utils/funcs.py
+++ b/daskqueue/utils/funcs.py
@@ -1,0 +1,12 @@
+import itertools
+from typing import Generator, Iterable
+from daskqueue.Protocol import Message
+
+
+def msg_grouper(n, iterable: Iterable, **kwargs) -> Generator:
+    it = iter(iterable)
+    while True:
+        chunk = tuple(itertools.islice(it, n))
+        if not chunk:
+            return
+        yield [Message(func, *args, **kwargs) for func, *args in chunk]

--- a/examples/perf_cpu_bound.py
+++ b/examples/perf_cpu_bound.py
@@ -19,22 +19,16 @@ if __name__ == "__main__":
     )
 
     ## Params
-    n_queues = 1
-    n_consumers = 5
+    n_queues = 2
+    n_consumers = 2
 
     queue_pool = QueuePool(client, n_queues)
 
     consumer_pool = ConsumerPool(client, queue_pool, n_consumers=n_consumers)
-
-    print(queue_pool)
-    print(consumer_pool)
 
     consumer_pool.start()
 
     for i in range(5):
         queue_pool.submit(process_item)
 
-    consumer_pool.join()
-
-    print(queue_pool)
-    print(consumer_pool)
+    consumer_pool.join(timestep=0.01, print_timestep=2, progress=True)

--- a/examples/perf_docs_pages.py
+++ b/examples/perf_docs_pages.py
@@ -1,0 +1,82 @@
+import os
+import argparse
+import asyncio
+import shutil
+from typing import List, Tuple
+import uuid
+
+import numpy as np
+from distributed import Client, Queue
+
+from daskqueue import ConsumerPool, QueuePool, ConsumerBaseClass
+from daskqueue.utils import logger
+
+
+def get_random_msg(
+    start_dir: str, dst_dir: str, l_files: List[str], size: int
+) -> List[Tuple[str, str]]:
+    """Generate a random copy list.
+    Will randomly choose a file in `start_dir` and create a copy.
+
+    Args:
+        start_dir (str): start directory
+        dst_dir(str): destination directory
+        l_files (List[str]): list of paths in directory
+        size (int): output size
+
+    Returns:
+        List[Tuple[str, str]]: _description_
+    """
+    msg = []
+    for _ in range(size):
+        idx = np.random.randint(len(l_files))
+        src = os.path.join(start_dir, l_files[idx])
+        dst = os.path.join(dst_dir, str(uuid.uuid1()))
+        msg.append((src, dst))
+    return msg
+
+
+class CopyWorker(ConsumerBaseClass):
+    ## You should always implement a concrete `process_item` where you define your processing code.
+    # Take a look at the Implementation Section
+    def process_item(self, item):
+        src, dst = item
+        logger.info(item)
+        # shutil.copy(src, dst)
+
+
+def main():
+
+    client = Client(
+        n_workers=5,
+        threads_per_worker=1,
+        dashboard_address=":3338",
+        direct_to_workers=True,
+    )
+
+    ## Params
+    start_dir = "/home/amine/Documents"
+    dst_dir = "/home/amine/Documents"
+    n_queues = 1
+    n_consumers = 2
+
+    # Queue Pool  with basic load balancing
+    queue_pool = QueuePool(client, n_queues)
+
+    # Start Consummers
+    consumer_pool = ConsumerPool(client, queue_pool, CopyWorker, n_consumers)
+    consumer_pool.start()
+
+    # Put copy Msg
+    l_files = os.listdir(start_dir)
+
+    for _ in range(10):
+        msg = get_random_msg(start_dir, dst_dir, l_files, size=1000)
+        queue_pool.put_many(msg)
+
+    ## Join to stop work
+    consumer_pool.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -21,7 +21,7 @@ logging.basicConfig(
 async def test_async_consumer_create(s, a, b):
     async with Client(s.address, asynchronous=True) as c:
         worker = c.submit(
-            DummyConsumer, "test-consumer", "test", workers=[a.address], actor=True
+            DummyConsumer, 1, "test-consumer", "test", workers=[a.address], actor=True
         )
         worker = await worker
         assert hasattr(worker, "get_items")
@@ -48,7 +48,7 @@ async def test_consummer_get_item(c, s, a, b):
         queue_pool = await c.submit(QueuePoolActor, 1, actor=True)
         await queue_pool.put(1)
         consumer = await c.submit(
-            DummyConsumer, "test-consumer", queue_pool, actor=True
+            DummyConsumer, 1, "test-consumer", queue_pool, actor=True
         )
         await consumer.start()
         res = await consumer.get_items()
@@ -62,7 +62,7 @@ async def test_consummer_get_item(c, s, a, b):
         await queue_pool.put(1)
         await queue_pool.put(1)
         consumer = await c.submit(
-            DummyConsumer, "test-consumer", queue_pool, actor=True
+            DummyConsumer, 1, "test-consumer", queue_pool, actor=True
         )
         await consumer.start()
         assert await consumer.consume_status() == False

--- a/tests/test_consumer_pool.py
+++ b/tests/test_consumer_pool.py
@@ -47,7 +47,7 @@ def test_consumer_pool_submit_pure(client):
     consumer_pool.join()
     res = consumer_pool.results()
     assert 10 * [2] == [val for k in res for val in res[k].values()]
-    assert sum(queue_pool.get_queue_size()) <= 0
+    assert sum(queue_pool.get_queue_size().values()) <= 0
 
 
 def test_consumer_pool_submit_noreturn(client):

--- a/tests/test_consumer_pool.py
+++ b/tests/test_consumer_pool.py
@@ -36,6 +36,7 @@ def test_consumer_pool_create(client):
 def test_consumer_pool_submit_pure(client):
     n_queues = 1
     queue_pool = QueuePool(client, n_queues)
+
     n_consumers = 2
     consumer_pool = ConsumerPool(client, queue_pool=queue_pool, n_consumers=n_consumers)
 
@@ -46,7 +47,7 @@ def test_consumer_pool_submit_pure(client):
     consumer_pool.join()
     res = consumer_pool.results()
     assert 10 * [2] == [val for k in res for val in res[k].values()]
-    assert sum(queue_pool.get_queue_size().values()) <= 0
+    assert sum(queue_pool.get_queue_size()) <= 0
 
 
 def test_consumer_pool_submit_noreturn(client):

--- a/tests/test_queue_pool.py
+++ b/tests/test_queue_pool.py
@@ -39,7 +39,7 @@ def test_queue_pool_inteface_create(client):
     n_queues = 2
     queue_pool = QueuePool(client, n_queues)
     assert n_queues == len(queue_pool)
-    assert 0 == sum(queue_pool.get_queue_size().values())
+    assert 0 == sum(queue_pool.get_queue_size())
     assert queue_pool[0].qsize().result() == 0
     assert queue_pool[1].qsize().result() == 0
     with pytest.raises(IndexError) as e_info:
@@ -59,17 +59,17 @@ def test_queuepool_inteface_put(client):
     n_queues = 1
     queue_pool = QueuePool(client, n_queues)
     _ = queue_pool.put(1)
-    assert 1 == sum(queue_pool.get_queue_size().values())
+    assert 1 == sum(queue_pool.get_queue_size())
     _ = queue_pool.put(1)
     _ = queue_pool.put(1)
-    assert 3 == sum(queue_pool.get_queue_size().values())
+    assert 3 == sum(queue_pool.get_queue_size())
 
 
 def test_queuepool_inteface_put_many(client):
     n_queues = 1
     queue_pool = QueuePool(client, n_queues)
     _ = queue_pool.put_many([1, 2, 3])
-    assert 3 == sum(queue_pool.get_queue_size().values())
+    assert 3 == sum(queue_pool.get_queue_size())
 
 
 def test_queuepool_inteface_submit(client):
@@ -80,11 +80,11 @@ def test_queuepool_inteface_submit(client):
         pass
 
     _ = queue_pool.submit(dummy_func)
-    assert 1 == sum(queue_pool.get_queue_size().values())
+    assert 1 == sum(queue_pool.get_queue_size())
 
     for _ in range(9):
         _ = queue_pool.submit(dummy_func)
-    assert 10 == sum(queue_pool.get_queue_size().values())
+    assert 10 == sum(queue_pool.get_queue_size())
 
 
 def test_queuepool_inteface_batch_submit(client):
@@ -95,7 +95,7 @@ def test_queuepool_inteface_batch_submit(client):
         pass
 
     _ = queue_pool.batch_submit([(dummy_func,) for _ in range(10)])
-    assert 10 == sum(queue_pool.get_queue_size().values())
+    assert 10 == sum(queue_pool.get_queue_size())
 
 
 def test_queuepool_inteface_submit_error(client):

--- a/tests/test_queue_pool.py
+++ b/tests/test_queue_pool.py
@@ -10,24 +10,6 @@ from distributed.utils_test import gen_cluster
 
 
 @gen_cluster(client=True, cluster_dump_directory=False)
-async def test_queue_getting_empty(c, s, a, b):
-    n_queues = 2
-    queue_pool = await c.submit(QueuePoolActor, n_queues, actor=True)
-    res = await queue_pool.get_nowait()
-    assert None == res
-    res = await queue_pool.get(timeout=1)
-    assert None == res
-
-
-@gen_cluster(client=True, cluster_dump_directory=False)
-async def test_put_queuepool(c, s, a, b):
-    n_queues = 2
-    queue_pool = await c.submit(QueuePoolActor, n_queues, actor=True)
-    res = await queue_pool.put(12)
-    assert None == res
-
-
-@gen_cluster(client=True, cluster_dump_directory=False)
 async def test_putmany_queuepool(c, s, a, b):
     n_queues = 2
     queue_pool = await c.submit(QueuePoolActor, n_queues, actor=True)
@@ -39,37 +21,28 @@ def test_queue_pool_inteface_create(client):
     n_queues = 2
     queue_pool = QueuePool(client, n_queues)
     assert n_queues == len(queue_pool)
-    assert 0 == sum(queue_pool.get_queue_size())
+    assert 0 == sum(queue_pool.get_queue_size().values())
     assert queue_pool[0].qsize().result() == 0
     assert queue_pool[1].qsize().result() == 0
     with pytest.raises(IndexError) as e_info:
         _ = queue_pool[3]
 
 
-def test_queuepool_inteface_get_fromempty(client):
-    n_queues = 1
-    queue_pool = QueuePool(client, n_queues)
-    res_get = queue_pool.get(timeout=1)
-    res_getnowait = queue_pool.get_nowait()
-    assert res_get == None
-    assert res_getnowait == None
-
-
 def test_queuepool_inteface_put(client):
     n_queues = 1
     queue_pool = QueuePool(client, n_queues)
     _ = queue_pool.put(1)
-    assert 1 == sum(queue_pool.get_queue_size())
+    assert 1 == sum(queue_pool.get_queue_size().values())
     _ = queue_pool.put(1)
     _ = queue_pool.put(1)
-    assert 3 == sum(queue_pool.get_queue_size())
+    assert 3 == sum(queue_pool.get_queue_size().values())
 
 
 def test_queuepool_inteface_put_many(client):
     n_queues = 1
     queue_pool = QueuePool(client, n_queues)
     _ = queue_pool.put_many([1, 2, 3])
-    assert 3 == sum(queue_pool.get_queue_size())
+    assert 3 == sum(queue_pool.get_queue_size().values())
 
 
 def test_queuepool_inteface_submit(client):
@@ -80,11 +53,11 @@ def test_queuepool_inteface_submit(client):
         pass
 
     _ = queue_pool.submit(dummy_func)
-    assert 1 == sum(queue_pool.get_queue_size())
+    assert 1 == sum(queue_pool.get_queue_size().values())
 
     for _ in range(9):
         _ = queue_pool.submit(dummy_func)
-    assert 10 == sum(queue_pool.get_queue_size())
+    assert 10 == sum(queue_pool.get_queue_size().values())
 
 
 def test_queuepool_inteface_batch_submit(client):
@@ -95,7 +68,7 @@ def test_queuepool_inteface_batch_submit(client):
         pass
 
     _ = queue_pool.batch_submit([(dummy_func,) for _ in range(10)])
-    assert 10 == sum(queue_pool.get_queue_size())
+    assert 10 == sum(queue_pool.get_queue_size().values())
 
 
 def test_queuepool_inteface_submit_error(client):


### PR DESCRIPTION
After running benchmarks on the current implementation, the scheduling algorithm changed for the following: 
- Batch submit : submit all items to 1 random queue > batch submit evenly distributes work on queues 
- Consumers : on start a consumer will get an assigned queue by the queuepool, the queuepool cycles through the _queues

This changes are a result of running several benchmark and tests. 

We aim to have as much performance measured in : high throughput, low submit_time and work_time.  
